### PR TITLE
fixed bug where media played after hiding screen

### DIFF
--- a/projectordisplayscreen.cpp
+++ b/projectordisplayscreen.cpp
@@ -302,9 +302,15 @@ void ProjectorDisplayScreen::renderPassiveText(QPixmap &back, bool useBack)
 {
     setTextPixmap(imGen.generateEmptyImage());
     if(useBack)
+    {
+        backType = B_PICTURE;
         setBackPixmap(back,0);
+    }
     else
+    {
+        backType = B_NONE;
         setBackPixmap(imGen.generateColorImage(m_color),0);
+    }
 
     updateScreen();
 }


### PR DESCRIPTION
Prevents video from restarting playback after you hide the display screen. Must build with Qt 5.12.2 where the QML Type "VideoOutput" shows an empty frame after video stops by default.